### PR TITLE
Added a tweak to: create build/ directory upon make; delete iso/ and build/ directories as a whole upon make clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/*
 /bin
 /isodir
+/iso
 /build
 /bin/artilleryos.iso
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ objects = ./build/loader.o \
           ./build/panic.o \
           ./build/render_image.o \
 
-
+_mkdir := $(shell mkdir -p build)
 
 # BASE KERNEL SOURCE
 build/%.o: kernel/src/%.c
@@ -82,7 +82,7 @@ install: kernel.elf
 	sudo cp $< /boot/mykernel.elf
 
 clean:
-	rm -rf ./build/*
+	rm -rf ./iso/
+	rm -rf ./build/
 	rm -f kernel.elf
 	rm -f artillery.iso
-


### PR DESCRIPTION
I noticed that upon calling the `make` command when freshly cloned, output files couldn't be created because the build directory was missing. Quick tweak added to create build directory upon calling `make`; Remove iso/ and build/ directories when calling `make clean`.
Further tweak added in .gitignore.