### PR TITLE
Reverse function removed from stdio.c, double printing works now.

### DIFF
--- a/kernel/libc/stdio.c
+++ b/kernel/libc/stdio.c
@@ -65,7 +65,7 @@ void ftoa(double num, char *buffer, int precision)
 	}
 
 	buffer[len + i] = '\0';
-	reverse(buffer, len + i);
+	// reverse(buffer, len + i);
 
 	// Add the negative sign if necessary
 	if (is_negative) {

--- a/kernel/libc/stdio.c
+++ b/kernel/libc/stdio.c
@@ -65,7 +65,6 @@ void ftoa(double num, char *buffer, int precision)
 	}
 
 	buffer[len + i] = '\0';
-	// reverse(buffer, len + i);
 
 	// Add the negative sign if necessary
 	if (is_negative) {


### PR DESCRIPTION
I removed the reverse function from stdio.c at line 68, though please correct me if I'm wrong. This shouldn't break anything.